### PR TITLE
[Refactor] 1차 QA 반영

### DIFF
--- a/core/common/src/main/java/com/example/common/event/HomeRefreshTrigger.kt
+++ b/core/common/src/main/java/com/example/common/event/HomeRefreshTrigger.kt
@@ -1,0 +1,16 @@
+package com.example.common.event
+
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class HomeRefreshTrigger
+    @Inject
+    constructor() {
+        private val _refreshEvent = MutableSharedFlow<Unit>()
+        val refreshEvent = _refreshEvent.asSharedFlow()
+
+        suspend fun refresh() = _refreshEvent.emit(Unit)
+    }

--- a/core/data/src/main/java/com/example/data/mapper/todomain/PostDetailResponseMapper.kt
+++ b/core/data/src/main/java/com/example/data/mapper/todomain/PostDetailResponseMapper.kt
@@ -9,6 +9,7 @@ fun PostDetailResponse.toDomain(): PostDetail =
         isHost = this.isHost,
         isScrapped = this.isScrapped,
         content = this.content,
+        date = this.displayDate,
         track = this.track.toDomain(),
         writer = this.user.toDomain(),
         like = this.like.toDomain(),

--- a/core/data/src/main/java/com/example/data/mapper/todomain/TodayPosteResponseMapper.kt
+++ b/core/data/src/main/java/com/example/data/mapper/todomain/TodayPosteResponseMapper.kt
@@ -1,10 +1,9 @@
 package com.example.data.mapper.todomain
 
-import com.example.data.model.response.BadgesResponse
 import com.example.data.model.response.TodayPostItemResponse
 import com.example.data.model.response.TodayPostTrackResponse
 import com.example.data.model.response.TodayPostsResponse
-import com.example.domain.model.Badges
+import com.example.domain.model.Badge
 import com.example.domain.model.DailyQuestion
 import com.example.domain.model.FeedItem
 import com.example.domain.model.HomeScreenData
@@ -29,17 +28,10 @@ fun TodayPostItemResponse.toDomain(): FeedItem =
         postId = postId,
         isScrapped = isScrapped,
         content = content,
-        badges = badges.toDomain(),
+        badge = badge?.let { Badge.valueOf(it) },
         track = track.toDomain(),
         writer = user.toDomain(),
         like = like.toDomain(),
-    )
-
-private fun BadgesResponse.toDomain(): Badges =
-    Badges(
-        isEditorPick = isEditorPick,
-        isPopular = isPopular,
-        isNew = isNew,
     )
 
 private fun TodayPostTrackResponse.toDomain(): Track =

--- a/core/data/src/main/java/com/example/data/mapper/todomain/TodayPosteResponseMapper.kt
+++ b/core/data/src/main/java/com/example/data/mapper/todomain/TodayPosteResponseMapper.kt
@@ -3,7 +3,7 @@ package com.example.data.mapper.todomain
 import com.example.data.model.response.TodayPostItemResponse
 import com.example.data.model.response.TodayPostTrackResponse
 import com.example.data.model.response.TodayPostsResponse
-import com.example.domain.model.Badge
+import com.example.domain.model.BADGE
 import com.example.domain.model.DailyQuestion
 import com.example.domain.model.FeedItem
 import com.example.domain.model.HomeScreenData
@@ -28,7 +28,7 @@ fun TodayPostItemResponse.toDomain(): FeedItem =
         postId = postId,
         isScrapped = isScrapped,
         content = content,
-        badge = badge?.let { Badge.valueOf(it) },
+        badge = badge?.let { BADGE.valueOf(it) },
         track = track.toDomain(),
         writer = user.toDomain(),
         like = like.toDomain(),

--- a/core/data/src/main/java/com/example/data/model/response/PostDetailResponse.kt
+++ b/core/data/src/main/java/com/example/data/model/response/PostDetailResponse.kt
@@ -13,6 +13,8 @@ data class PostDetailResponse(
     val isScrapped: Boolean,
     @SerialName("content")
     val content: String,
+    @SerialName("displayDate")
+    val displayDate: String,
     @SerialName("track")
     val track: TrackResponse,
     @SerialName("user")

--- a/core/data/src/main/java/com/example/data/model/response/QuestionPostsResponse.kt
+++ b/core/data/src/main/java/com/example/data/model/response/QuestionPostsResponse.kt
@@ -1,6 +1,6 @@
 package com.example.data.model.response
 
-import com.example.domain.model.Badge
+import com.example.domain.model.BADGE
 import com.example.domain.model.FeedItem
 import com.example.domain.model.Like
 import com.example.domain.model.Track
@@ -34,8 +34,8 @@ data class QuestionPostsResponse(
 data class QuestionPostItemResponse(
     @SerialName("postId")
     val postId: Long,
-    @SerialName("badge")
-    val badge: String?,
+    @SerialName("isEditorPick")
+    val isEditorPick: Boolean,
     @SerialName("isScrapped")
     val isScrapped: Boolean,
     @SerialName("content")
@@ -52,7 +52,7 @@ data class QuestionPostItemResponse(
             postId = postId,
             isScrapped = isScrapped,
             content = content,
-            badge = badge?.let { Badge.valueOf(it) },
+            badge = if (isEditorPick) BADGE.EDITOR else null,
             track =
                 Track(
                     trackId = track.trackId,

--- a/core/data/src/main/java/com/example/data/model/response/QuestionPostsResponse.kt
+++ b/core/data/src/main/java/com/example/data/model/response/QuestionPostsResponse.kt
@@ -1,6 +1,6 @@
 package com.example.data.model.response
 
-import com.example.domain.model.Badges
+import com.example.domain.model.Badge
 import com.example.domain.model.FeedItem
 import com.example.domain.model.Like
 import com.example.domain.model.Track
@@ -34,8 +34,8 @@ data class QuestionPostsResponse(
 data class QuestionPostItemResponse(
     @SerialName("postId")
     val postId: Long,
-    @SerialName("isEditorPick")
-    val isEditorPick: Boolean,
+    @SerialName("badge")
+    val badge: String?,
     @SerialName("isScrapped")
     val isScrapped: Boolean,
     @SerialName("content")
@@ -52,12 +52,7 @@ data class QuestionPostItemResponse(
             postId = postId,
             isScrapped = isScrapped,
             content = content,
-            badges =
-                Badges(
-                    isEditorPick = isEditorPick,
-                    isPopular = false,
-                    isNew = false,
-                ),
+            badge = badge?.let { Badge.valueOf(it) },
             track =
                 Track(
                     trackId = track.trackId,

--- a/core/data/src/main/java/com/example/data/model/response/TodayPostsResponse.kt
+++ b/core/data/src/main/java/com/example/data/model/response/TodayPostsResponse.kt
@@ -19,17 +19,10 @@ data class TodayPostItemResponse(
     @SerialName("postId") val postId: Long,
     @SerialName("isScrapped") val isScrapped: Boolean,
     @SerialName("content") val content: String,
-    @SerialName("badges") val badges: BadgesResponse,
+    @SerialName("badge") val badge: String?,
     @SerialName("track") val track: TodayPostTrackResponse,
     @SerialName("user") val user: UserResponse,
     @SerialName("like") val like: LikeResponse,
-)
-
-@Serializable
-data class BadgesResponse(
-    @SerialName("isEditorPick") val isEditorPick: Boolean,
-    @SerialName("isPopular") val isPopular: Boolean,
-    @SerialName("isNew") val isNew: Boolean,
 )
 
 @Serializable

--- a/core/designsystem/src/main/java/com/example/designsystem/component/DPlayBottomSheet.kt
+++ b/core/designsystem/src/main/java/com/example/designsystem/component/DPlayBottomSheet.kt
@@ -108,6 +108,7 @@ fun DPlayTitleButtonBottomSheet(
     onButtonClick: () -> Unit,
     onCloseClick: () -> Unit,
     modifier: Modifier = Modifier,
+    isButtonEnabled: Boolean = true,
     content: @Composable ColumnScope.() -> Unit,
 ) {
     val bottomSheetShape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp)
@@ -164,39 +165,36 @@ fun DPlayTitleButtonBottomSheet(
                     .padding(horizontal = 8.5.dp),
             onClick = onButtonClick,
             label = buttonText,
+            enabled = isButtonEnabled,
         )
     }
 }
 
 @Composable
 fun DPlayReportBottomSheet(
-    onButtonClick: (selectedReasons: List<DPlayReportReason>) -> Unit,
+    onButtonClick: (selectedReason: DPlayReportReason) -> Unit,
     onCloseClick: () -> Unit,
     modifier: Modifier = Modifier,
     onCheckClick: ((DPlayReportReason) -> Unit)? = null,
     reasons: List<DPlayReportReason> = DPlayReportReason.entries,
 ) {
-    var selectedReasons by remember { mutableStateOf(setOf<DPlayReportReason>()) }
+    var selectedReason by remember { mutableStateOf<DPlayReportReason?>(null) }
 
     DPlayTitleButtonBottomSheet(
         titleText = stringResource(R.string.report_bottom_sheet_title),
         buttonText = "신고하기",
-        onButtonClick = { onButtonClick(selectedReasons.toList()) },
+        onButtonClick = { selectedReason?.let { onButtonClick(it) } },
         onCloseClick = onCloseClick,
         modifier = modifier,
+        isButtonEnabled = selectedReason != null,
     ) {
         reasons.forEach { reason ->
-            val isChecked = reason in selectedReasons
+            val isChecked = reason == selectedReason
             DPlayCheck(
                 text = stringResource(reason.stringResId),
                 isChecked = isChecked,
                 onClick = {
-                    selectedReasons =
-                        if (isChecked) {
-                            selectedReasons - reason
-                        } else {
-                            selectedReasons + reason
-                        }
+                    selectedReason = if (isChecked) null else reason
                     onCheckClick?.invoke(reason)
                 },
                 modifier = Modifier.fillMaxWidth(),

--- a/core/designsystem/src/main/java/com/example/designsystem/component/DPlayLargeCover.kt
+++ b/core/designsystem/src/main/java/com/example/designsystem/component/DPlayLargeCover.kt
@@ -37,7 +37,6 @@ import com.example.designsystem.util.roundedBackgroundWithPadding
 
 @Composable
 fun DPlayLargeCover(
-    isBookmarkChecked: Boolean,
     isLikeChecked: Boolean,
     likeCount: Int,
     writerProfileImageUrl: String?,
@@ -48,10 +47,8 @@ fun DPlayLargeCover(
     onWriterProfileClick: () -> Unit,
     onStreamClick: () -> Unit,
     onLikeClick: () -> Unit,
-    onBookmarkClick: () -> Unit,
     modifier: Modifier = Modifier,
     isLocked: Boolean = true,
-    bookmarkIconVisible: Boolean = true,
     isStreaming: Boolean = false,
 ) {
     val color = DPlayTheme.colors
@@ -90,25 +87,6 @@ fun DPlayLargeCover(
                         .onSizeChanged { discHeightPx = it.height }
                         .align(Alignment.TopCenter),
             )
-
-            if (bookmarkIconVisible && !isLocked) {
-                DplayClickableIcon(
-                    iconRes =
-                        if (isBookmarkChecked) {
-                            R.drawable.ic_bookmark_filled_24
-                        } else {
-                            R.drawable.ic_bookmark_unfilled_24
-                        },
-                    modifier =
-                        Modifier
-                            .roundedBackgroundWithPadding(
-                                backgroundColor = color.gray600,
-                                padding = PaddingValues(10.dp),
-                                cornerRadius = 12.dp,
-                            ).align(Alignment.TopEnd),
-                    onClick = onBookmarkClick,
-                )
-            }
 
             Column(
                 modifier =
@@ -229,7 +207,6 @@ fun DPlayLargeCover(
 private fun DPlayLargeCoverPreview() {
     DPlayTheme {
         DPlayLargeCover(
-            isBookmarkChecked = true,
             isLikeChecked = false,
             likeCount = 24,
             writerProfileImageUrl = "",
@@ -238,7 +215,6 @@ private fun DPlayLargeCoverPreview() {
             musicImageUrl = "",
             onStreamClick = {},
             onLikeClick = {},
-            onBookmarkClick = {},
             onCoverClick = {},
             onWriterProfileClick = {},
         )

--- a/core/designsystem/src/main/java/com/example/designsystem/component/DPlayLargeCover.kt
+++ b/core/designsystem/src/main/java/com/example/designsystem/component/DPlayLargeCover.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -33,7 +32,6 @@ import coil3.compose.AsyncImage
 import com.dplay.designsystem.R
 import com.example.designsystem.theme.DPlayTheme
 import com.example.designsystem.util.noRippleClickable
-import com.example.designsystem.util.roundedBackgroundWithPadding
 
 @Composable
 fun DPlayLargeCover(

--- a/core/designsystem/src/main/java/com/example/designsystem/component/DPlayMusicGridItem.kt
+++ b/core/designsystem/src/main/java/com/example/designsystem/component/DPlayMusicGridItem.kt
@@ -9,6 +9,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.example.designsystem.theme.DPlayTheme
@@ -30,9 +31,22 @@ fun DPlayMusicGridItem(
                     .fillMaxWidth(),
         )
         Spacer(modifier = Modifier.height(5.dp))
-        Text(text = musicName, style = DPlayTheme.typography.bodySemi14, color = DPlayTheme.colors.dplayBlack)
+        Text(
+            text = musicName,
+            style = DPlayTheme.typography.bodySemi14,
+            color = DPlayTheme.colors.dplayBlack,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
         Spacer(modifier = Modifier.height(1.dp))
-        Text(text = musicArtistName, style = DPlayTheme.typography.capMed12, color = DPlayTheme.colors.gray400)
+        Text(
+            text = musicArtistName,
+            style = DPlayTheme.typography.capMed12,
+            color = DPlayTheme.colors.gray400,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+
     }
 }
 

--- a/core/designsystem/src/main/java/com/example/designsystem/component/DPlayMusicGridItem.kt
+++ b/core/designsystem/src/main/java/com/example/designsystem/component/DPlayMusicGridItem.kt
@@ -46,7 +46,6 @@ fun DPlayMusicGridItem(
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
         )
-
     }
 }
 

--- a/core/designsystem/src/main/java/com/example/designsystem/component/DPlayMusicListItem.kt
+++ b/core/designsystem/src/main/java/com/example/designsystem/component/DPlayMusicListItem.kt
@@ -36,8 +36,8 @@ fun DPlayMusicListItem(
     musicName: String,
     musicArtistName: String,
     musicContent: String,
-    onMoreClick: () -> Unit,
     modifier: Modifier = Modifier,
+    onMoreClick: (() -> Unit)? = null,
     isEditorPick: Boolean = false,
     onClick: () -> Unit = {},
 ) {
@@ -69,11 +69,13 @@ fun DPlayMusicListItem(
             )
             Spacer(modifier = Modifier.width(8.dp))
             Column(modifier = Modifier.weight(1f)) {
-                DplayClickableIcon(
-                    iconRes = R.drawable.ic_more_gray_20,
-                    onClick = onMoreClick,
-                    modifier = Modifier.align(Alignment.End),
-                )
+                onMoreClick?.let {
+                    DplayClickableIcon(
+                        iconRes = R.drawable.ic_more_gray_20,
+                        onClick = it,
+                        modifier = Modifier.align(Alignment.End),
+                    )
+                }
                 BoxWithConstraints {
                     val maxTitleWidth = maxWidth * 0.5f
 

--- a/core/domain/src/main/java/com/example/domain/model/FeedItem.kt
+++ b/core/domain/src/main/java/com/example/domain/model/FeedItem.kt
@@ -1,5 +1,6 @@
 package com.example.domain.model
 
+
 data class FeedItem(
     val postId: Long,
     val isScrapped: Boolean,

--- a/core/domain/src/main/java/com/example/domain/model/FeedItem.kt
+++ b/core/domain/src/main/java/com/example/domain/model/FeedItem.kt
@@ -4,14 +4,14 @@ data class FeedItem(
     val postId: Long,
     val isScrapped: Boolean,
     val content: String,
-    val badges: Badges,
+    val badge: BADGE?,
     val track: Track,
     val writer: Writer,
     val like: Like,
 )
 
-data class Badges(
-    val isEditorPick: Boolean,
-    val isPopular: Boolean,
-    val isNew: Boolean,
-)
+enum class BADGE {
+    EDITOR,
+    BEST,
+    NEW,
+}

--- a/core/domain/src/main/java/com/example/domain/model/PostDetail.kt
+++ b/core/domain/src/main/java/com/example/domain/model/PostDetail.kt
@@ -1,11 +1,21 @@
 package com.example.domain.model
 
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
 data class PostDetail(
     val postId: Long,
     val isHost: Boolean,
     val isScrapped: Boolean,
     val content: String,
+    private val date: String,
     val track: Track,
     val writer: Writer,
     val like: Like,
-)
+) {
+    val displayDate: String
+        get() = runCatching {
+            val parsedDate = LocalDate.parse(date, DateTimeFormatter.ISO_DATE)
+            "${parsedDate.monthValue}월 ${parsedDate.dayOfMonth}일"
+        }.getOrElse { "알 수 없는 날짜" }
+}

--- a/core/navigation/build.gradle.kts
+++ b/core/navigation/build.gradle.kts
@@ -11,5 +11,6 @@ dependencies {
     implementation(libs.kotlinx.serialization.json)
     implementation(projects.core.designsystem)
     implementation(projects.core.common)
+    implementation(projects.core.domain)
     implementation(projects.core.ui)
 }

--- a/core/navigation/src/main/java/com/example/navigation/Navigator.kt
+++ b/core/navigation/src/main/java/com/example/navigation/Navigator.kt
@@ -20,7 +20,7 @@ class Navigator(
     val shouldShowBottomSheet: Boolean
         get() = backStack.lastOrNull() is TopLevelRoute
 
-    val topLevelRoutes: ImmutableList<TopLevelRoute> = persistentListOf(Home, MyPage)
+    val topLevelRoutes: ImmutableList<TopLevelRoute> = persistentListOf(Home, MyPage())
 
     fun navigateToTopLevelRoute(destination: TopLevelRoute) {
         clearAndNavigateTo(destination as NavKey)

--- a/core/navigation/src/main/java/com/example/navigation/Route.kt
+++ b/core/navigation/src/main/java/com/example/navigation/Route.kt
@@ -3,6 +3,7 @@ package com.example.navigation
 import androidx.annotation.DrawableRes
 import androidx.navigation3.runtime.NavKey
 import com.dplay.designsystem.R
+import com.example.domain.model.BADGE
 import com.example.ui.model.TrackState
 import kotlinx.serialization.Serializable
 
@@ -62,5 +63,5 @@ data object Record : NavKey
 @Serializable
 data class Detail(
     val postId: Long,
-    val date: String = "",
+    val badge: BADGE? = null,
 ) : NavKey

--- a/core/navigation/src/main/java/com/example/navigation/Route.kt
+++ b/core/navigation/src/main/java/com/example/navigation/Route.kt
@@ -22,7 +22,15 @@ data object Home : TopLevelRoute, NavKey {
         get() = R.drawable.ic_home_disabled_32
 }
 
-data object MyPage : TopLevelRoute, NavKey {
+enum class MyPageTab {
+    REGISTERED,
+    BOOKMARKED,
+}
+
+data class MyPage(
+    val initialTab: MyPageTab = MyPageTab.REGISTERED,
+) : TopLevelRoute,
+    NavKey {
     override val selectedIconRes: Int
         get() = R.drawable.ic_bookmark_active_32
     override val unselectedIconRes: Int

--- a/feature/comment/src/main/java/com/example/comment/CommentViewModel.kt
+++ b/feature/comment/src/main/java/com/example/comment/CommentViewModel.kt
@@ -2,6 +2,7 @@ package com.example.comment
 
 import androidx.lifecycle.viewModelScope
 import com.example.common.constant.Url
+import com.example.common.event.HomeRefreshTrigger
 import com.example.domain.repository.PostRepository
 import com.example.ui.base.BaseViewModel
 import com.example.ui.model.TrackState
@@ -15,6 +16,7 @@ class CommentViewModel
     @Inject
     constructor(
         private val postRepository: PostRepository,
+        private val homeRefreshTrigger: HomeRefreshTrigger,
     ) : BaseViewModel<CommentContract.CommentState, CommentContract.CommentIntent, CommentContract.CommentSideEffect>(
             CommentContract.CommentState(),
         ) {
@@ -60,6 +62,7 @@ class CommentViewModel
                         track = track,
                         comment = currentState.commentInput,
                     ).onSuccess {
+                        homeRefreshTrigger.refresh()
                         setSideEffect(CommentContract.CommentSideEffect.NavigateToHome)
                     }.onFailure {
                     }

--- a/feature/detail/src/main/java/com/example/detail/DetailContract.kt
+++ b/feature/detail/src/main/java/com/example/detail/DetailContract.kt
@@ -1,6 +1,7 @@
 package com.example.detail
 
 import com.example.designsystem.component.snackbar.type.SnackBarType
+import com.example.domain.model.BADGE
 import com.example.domain.model.Like
 import com.example.domain.model.Track
 import com.example.domain.model.Writer
@@ -12,6 +13,7 @@ class DetailContract {
         val isScrapped: Boolean = false,
         val content: String = "",
         val isHost: Boolean = false,
+        val date: String = "",
         val track: Track =
             Track(
                 trackId = "",
@@ -31,18 +33,15 @@ class DetailContract {
                 isLiked = false,
                 count = 0,
             ),
-        val date: String = "2025-10-19",
+        val badge: BADGE? = null,
         val bottomSheetVisible: Boolean = false,
         val streamingTrackId: String? = null,
-        val currentUserId: Long = 0L,
-    ) : BaseContract.State {
-        val isMyPost: Boolean get() = currentUserId != 0L && currentUserId == writer.userId
-    }
+    ) : BaseContract.State
 
     sealed interface DetailIntent : BaseContract.Intent {
         data class LoadData(
             val postId: Long,
-            val date: String = "",
+            val badge: BADGE? = null,
         ) : DetailIntent
 
         data object OnBookmarkClick : DetailIntent

--- a/feature/detail/src/main/java/com/example/detail/DetailContract.kt
+++ b/feature/detail/src/main/java/com/example/detail/DetailContract.kt
@@ -62,12 +62,16 @@ class DetailContract {
 
         data object OnDeleteClick : DetailIntent
 
+        data object OnDeleteConfirmClick : DetailIntent
+
         data class ChangeBottomSheetVisible(
             val visible: Boolean,
         ) : DetailIntent
     }
 
     sealed interface DetailSideEffect : BaseContract.SideEffect {
+        data object ShowDeleteConfirmModal : DetailSideEffect
+
         data object NavigateBackStack : DetailSideEffect
 
         data object NavigateToWriterProfile : DetailSideEffect

--- a/feature/detail/src/main/java/com/example/detail/DetailNavigationModule.kt
+++ b/feature/detail/src/main/java/com/example/detail/DetailNavigationModule.kt
@@ -20,7 +20,7 @@ object DetailNavigationModule {
     ): EntryProviderScope<NavKey>.() -> Unit =
         {
             entry<Detail> { args ->
-                DetailRoute(postId = args.postId, navigator = navigator, date = args.date)
+                DetailRoute(postId = args.postId, navigator = navigator, badge = args.badge)
             }
         }
 }

--- a/feature/detail/src/main/java/com/example/detail/DetailScreen.kt
+++ b/feature/detail/src/main/java/com/example/detail/DetailScreen.kt
@@ -174,11 +174,12 @@ private fun DetailScreen(
                         modifier = Modifier.align(Alignment.TopEnd),
                     )
                     state.badge?.let { badge ->
-                        val chipType = when (badge) {
-                            BADGE.BEST -> DPlayChipType.BEST
-                            BADGE.EDITOR -> DPlayChipType.EDITOR
-                            BADGE.NEW -> DPlayChipType.NEW
-                        }
+                        val chipType =
+                            when (badge) {
+                                BADGE.BEST -> DPlayChipType.BEST
+                                BADGE.EDITOR -> DPlayChipType.EDITOR
+                                BADGE.NEW -> DPlayChipType.NEW
+                            }
                         DPlayChip(
                             type = chipType,
                             modifier = Modifier.align(Alignment.BottomCenter),

--- a/feature/detail/src/main/java/com/example/detail/DetailScreen.kt
+++ b/feature/detail/src/main/java/com/example/detail/DetailScreen.kt
@@ -316,7 +316,7 @@ private fun DetailScreen(
             } else {
                 DPlayReportBottomSheet(
                     onCloseClick = { changeBottomSheetVisible(false) },
-                    onButtonClick = { changeBottomSheetVisible(false) },
+                    onButtonClick = { _ -> changeBottomSheetVisible(false) },
                     modifier = bottomSheetModifier,
                 )
             }

--- a/feature/detail/src/main/java/com/example/detail/DetailScreen.kt
+++ b/feature/detail/src/main/java/com/example/detail/DetailScreen.kt
@@ -43,6 +43,7 @@ import com.example.designsystem.component.chip.DPlayChip
 import com.example.designsystem.component.chip.type.DPlayChipType
 import com.example.designsystem.component.snackbar.LocalShowSnackBar
 import com.example.designsystem.theme.DPlayTheme
+import com.example.ui.controller.LocalModalController
 import com.example.designsystem.util.noRippleClickable
 import com.example.designsystem.util.roundedBackgroundWithPadding
 import com.example.domain.model.BADGE
@@ -58,6 +59,7 @@ fun DetailRoute(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val showSnackBar = LocalShowSnackBar.current
+    val modalController = LocalModalController.current
 
     LaunchedEffect(Unit) {
         viewModel.handleIntent(DetailContract.DetailIntent.LoadData(postId = postId, badge = badge))
@@ -80,6 +82,25 @@ fun DetailRoute(
 
                 is DetailContract.DetailSideEffect.NavigateToMyPage -> {
                     // TODO
+                }
+
+                is DetailContract.DetailSideEffect.ShowDeleteConfirmModal -> {
+                    modalController.showWarningModal(
+                        mainText = "정말 삭제하시겠어요?",
+                        subText = "삭제된 글은 복구할 수 없어요",
+                        leftButtonLabel = "취소",
+                        rightButtonLabel = "삭제",
+                        onLeftButtonClick = {
+                            modalController.hideModal()
+                        },
+                        onRightButtonClick = {
+                            modalController.hideModal()
+                            viewModel.handleIntent(DetailContract.DetailIntent.OnDeleteConfirmClick)
+                        },
+                        onDismiss = {
+                            modalController.hideModal()
+                        },
+                    )
                 }
             }
         }

--- a/feature/detail/src/main/java/com/example/detail/DetailScreen.kt
+++ b/feature/detail/src/main/java/com/example/detail/DetailScreen.kt
@@ -43,11 +43,13 @@ import com.example.designsystem.component.chip.DPlayChip
 import com.example.designsystem.component.chip.type.DPlayChipType
 import com.example.designsystem.component.snackbar.LocalShowSnackBar
 import com.example.designsystem.theme.DPlayTheme
-import com.example.ui.controller.LocalModalController
 import com.example.designsystem.util.noRippleClickable
 import com.example.designsystem.util.roundedBackgroundWithPadding
 import com.example.domain.model.BADGE
+import com.example.navigation.MyPage
+import com.example.navigation.MyPageTab
 import com.example.navigation.Navigator
+import com.example.ui.controller.LocalModalController
 import kotlinx.coroutines.flow.collectLatest
 
 @Composable
@@ -81,7 +83,7 @@ fun DetailRoute(
                 }
 
                 is DetailContract.DetailSideEffect.NavigateToMyPage -> {
-                    // TODO
+                    navigator.navigateTo(destination = MyPage(initialTab = MyPageTab.BOOKMARKED))
                 }
 
                 is DetailContract.DetailSideEffect.ShowDeleteConfirmModal -> {

--- a/feature/detail/src/main/java/com/example/detail/DetailScreen.kt
+++ b/feature/detail/src/main/java/com/example/detail/DetailScreen.kt
@@ -45,6 +45,7 @@ import com.example.designsystem.component.snackbar.LocalShowSnackBar
 import com.example.designsystem.theme.DPlayTheme
 import com.example.designsystem.util.noRippleClickable
 import com.example.designsystem.util.roundedBackgroundWithPadding
+import com.example.domain.model.BADGE
 import com.example.navigation.Navigator
 import kotlinx.coroutines.flow.collectLatest
 
@@ -53,13 +54,13 @@ fun DetailRoute(
     postId: Long,
     navigator: Navigator,
     viewModel: DetailViewModel = hiltViewModel(),
-    date: String = "",
+    badge: BADGE? = null,
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val showSnackBar = LocalShowSnackBar.current
 
     LaunchedEffect(Unit) {
-        viewModel.handleIntent(DetailContract.DetailIntent.LoadData(postId = postId, date = date))
+        viewModel.handleIntent(DetailContract.DetailIntent.LoadData(postId = postId, badge = badge))
     }
 
     LaunchedEffect(viewModel.sideEffect) {
@@ -172,9 +173,14 @@ private fun DetailScreen(
                         onClick = onBookmarkClick,
                         modifier = Modifier.align(Alignment.TopEnd),
                     )
-                    if (state.isHost) {
+                    state.badge?.let { badge ->
+                        val chipType = when (badge) {
+                            BADGE.BEST -> DPlayChipType.BEST
+                            BADGE.EDITOR -> DPlayChipType.EDITOR
+                            BADGE.NEW -> DPlayChipType.NEW
+                        }
                         DPlayChip(
-                            type = DPlayChipType.EDITOR,
+                            type = chipType,
                             modifier = Modifier.align(Alignment.BottomCenter),
                         )
                     }
@@ -272,7 +278,7 @@ private fun DetailScreen(
                         .noRippleClickable { changeBottomSheetVisible(false) },
             )
 
-            if (state.isMyPost) {
+            if (state.isHost) {
                 DPlayButtonBottomSheet(
                     mainText = "삭제하기",
                     subText = "취소하기",

--- a/feature/detail/src/main/java/com/example/detail/DetailViewModel.kt
+++ b/feature/detail/src/main/java/com/example/detail/DetailViewModel.kt
@@ -55,7 +55,12 @@ class DetailViewModel
                 }
 
                 is DetailContract.DetailIntent.OnBookmarkClick -> toggleBookmark()
-                is DetailContract.DetailIntent.OnDeleteClick -> deletePost()
+                is DetailContract.DetailIntent.OnDeleteClick -> {
+                    changeBottomSheetVisible(visible = false)
+                    setSideEffect(DetailContract.DetailSideEffect.ShowDeleteConfirmModal)
+                }
+
+                is DetailContract.DetailIntent.OnDeleteConfirmClick -> deletePost()
                 is DetailContract.DetailIntent.OnLikeClick -> toggleLike()
                 is DetailContract.DetailIntent.OnMeatBallsClick -> {
                     changeBottomSheetVisible(visible = true)
@@ -163,10 +168,8 @@ class DetailViewModel
                 postRepository
                     .deletePost(postId = currentState.postId)
                     .onSuccess {
-                        changeBottomSheetVisible(visible = false)
                         setSideEffect(DetailContract.DetailSideEffect.NavigateBackStack)
                     }.onFailure { e ->
-                        changeBottomSheetVisible(visible = false)
                         Timber.e(e)
                     }
             }

--- a/feature/detail/src/main/java/com/example/detail/DetailViewModel.kt
+++ b/feature/detail/src/main/java/com/example/detail/DetailViewModel.kt
@@ -5,13 +5,12 @@ import com.example.common.audio.AudioPlayer
 import com.example.designsystem.component.snackbar.type.SnackBarType
 import com.example.detail.DetailContract.DetailSideEffect.NavigateToMyPage
 import com.example.detail.DetailContract.DetailSideEffect.ShowSnackBar
+import com.example.domain.model.BADGE
 import com.example.domain.model.Like
 import com.example.domain.repository.PostRepository
 import com.example.domain.repository.TrackRepository
-import com.example.domain.repository.UserRepository
 import com.example.ui.base.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -25,7 +24,6 @@ class DetailViewModel
         private val postRepository: PostRepository,
         private val trackRepository: TrackRepository,
         private val audioPlayer: AudioPlayer,
-        private val userRepository: UserRepository,
     ) : BaseViewModel<DetailContract.DetailState, DetailContract.DetailIntent, DetailContract.DetailSideEffect>(
             DetailContract.DetailState(),
         ) {
@@ -51,7 +49,7 @@ class DetailViewModel
 
         override fun handleIntent(intent: DetailContract.DetailIntent) {
             when (intent) {
-                is DetailContract.DetailIntent.LoadData -> loadData(intent.postId, intent.date)
+                is DetailContract.DetailIntent.LoadData -> loadData(intent.postId, intent.badge)
                 is DetailContract.DetailIntent.OnBackButtonClick -> {
                     setSideEffect(DetailContract.DetailSideEffect.NavigateBackStack)
                 }
@@ -77,11 +75,9 @@ class DetailViewModel
 
         private fun loadData(
             postId: Long,
-            date: String,
+            badge: BADGE?,
         ) {
             viewModelScope.launch {
-                val currentUserId = userRepository.getUser().first()?.id ?: 0L
-
                 postRepository
                     .getPostDetail(postId = postId)
                     .onSuccess { postDetail ->
@@ -91,11 +87,11 @@ class DetailViewModel
                                 isScrapped = postDetail.isScrapped,
                                 content = postDetail.content,
                                 isHost = postDetail.isHost,
+                                date = postDetail.displayDate,
                                 track = postDetail.track,
                                 writer = postDetail.writer,
                                 like = postDetail.like,
-                                date = date,
-                                currentUserId = currentUserId,
+                                badge = badge,
                             )
                         }
                     }.onFailure { e ->

--- a/feature/detail/src/main/java/com/example/detail/DetailViewModel.kt
+++ b/feature/detail/src/main/java/com/example/detail/DetailViewModel.kt
@@ -2,6 +2,7 @@ package com.example.detail
 
 import androidx.lifecycle.viewModelScope
 import com.example.common.audio.AudioPlayer
+import com.example.common.event.HomeRefreshTrigger
 import com.example.designsystem.component.snackbar.type.SnackBarType
 import com.example.detail.DetailContract.DetailSideEffect.NavigateToMyPage
 import com.example.detail.DetailContract.DetailSideEffect.ShowSnackBar
@@ -24,6 +25,7 @@ class DetailViewModel
         private val postRepository: PostRepository,
         private val trackRepository: TrackRepository,
         private val audioPlayer: AudioPlayer,
+        private val homeRefreshTrigger: HomeRefreshTrigger,
     ) : BaseViewModel<DetailContract.DetailState, DetailContract.DetailIntent, DetailContract.DetailSideEffect>(
             DetailContract.DetailState(),
         ) {
@@ -168,6 +170,7 @@ class DetailViewModel
                 postRepository
                     .deletePost(postId = currentState.postId)
                     .onSuccess {
+                        homeRefreshTrigger.refresh()
                         setSideEffect(DetailContract.DetailSideEffect.NavigateBackStack)
                     }.onFailure { e ->
                         Timber.e(e)

--- a/feature/home/src/main/java/com/example/home/HomeContract.kt
+++ b/feature/home/src/main/java/com/example/home/HomeContract.kt
@@ -72,5 +72,7 @@ class HomeContract {
         ) : HomeSideEffect
 
         data object NavigateToMyPage : HomeSideEffect
+
+        data object ScrollToFirstPage : HomeSideEffect
     }
 }

--- a/feature/home/src/main/java/com/example/home/HomeContract.kt
+++ b/feature/home/src/main/java/com/example/home/HomeContract.kt
@@ -48,9 +48,12 @@ class HomeContract {
         data class OnCoverClick(
             val postId: Long,
         ) : HomeIntent
+
+        data object OnLockedCoverClick : HomeIntent
     }
 
     sealed interface HomeSideEffect : BaseContract.SideEffect {
+        data object ShowLockedModal : HomeSideEffect
         data class NavigateToWriterProfile(
             val writerUserId: Long,
         ) : HomeSideEffect

--- a/feature/home/src/main/java/com/example/home/HomeContract.kt
+++ b/feature/home/src/main/java/com/example/home/HomeContract.kt
@@ -25,8 +25,6 @@ class HomeContract {
     ) : BaseContract.State
 
     sealed interface HomeIntent : BaseContract.Intent {
-        data object LoadHomeData : HomeIntent
-
         data object OnRefreshClick : HomeIntent
 
         data class OnBookmarkClick(

--- a/feature/home/src/main/java/com/example/home/HomeContract.kt
+++ b/feature/home/src/main/java/com/example/home/HomeContract.kt
@@ -1,6 +1,7 @@
 package com.example.home
 
 import com.example.designsystem.component.snackbar.type.SnackBarType
+import com.example.domain.model.BADGE
 import com.example.domain.model.DailyQuestion
 import com.example.domain.model.FeedItem
 import com.example.ui.base.BaseContract
@@ -58,6 +59,7 @@ class HomeContract {
 
         data class NavigateToPostDetail(
             val postId: Long,
+            val badge: BADGE?,
         ) : HomeSideEffect
 
         data object NavigateToRecord : HomeSideEffect

--- a/feature/home/src/main/java/com/example/home/HomeContract.kt
+++ b/feature/home/src/main/java/com/example/home/HomeContract.kt
@@ -54,6 +54,7 @@ class HomeContract {
 
     sealed interface HomeSideEffect : BaseContract.SideEffect {
         data object ShowLockedModal : HomeSideEffect
+
         data class NavigateToWriterProfile(
             val writerUserId: Long,
         ) : HomeSideEffect

--- a/feature/home/src/main/java/com/example/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/example/home/HomeScreen.kt
@@ -46,10 +46,6 @@ fun HomeRoute(
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     val showSnackBar = LocalShowSnackBar.current
 
-    LaunchedEffect(Unit) {
-        viewModel.handleIntent(HomeContract.HomeIntent.LoadHomeData)
-    }
-
     LaunchedEffect(viewModel.sideEffect) {
         viewModel.sideEffect.collectLatest {
             when (it) {

--- a/feature/home/src/main/java/com/example/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/example/home/HomeScreen.kt
@@ -204,7 +204,6 @@ private fun HomePager(
     onLockedCoverClick: () -> Unit,
     uiState: HomeContract.HomeState,
 ) {
-
     val currentItem = feedItems.getOrNull(pagerState.currentPage)
     val isCurrentPageLocked = uiState.locked && pagerState.currentPage >= 3
     val currentChipType: DPlayChipType? =

--- a/feature/home/src/main/java/com/example/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/example/home/HomeScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -35,13 +34,14 @@ import com.example.designsystem.component.snackbar.LocalShowSnackBar
 import com.example.designsystem.theme.DPlayTheme
 import com.example.domain.model.BADGE
 import com.example.domain.model.FeedItem
-import com.example.ui.controller.LocalModalController
 import com.example.navigation.Detail
+import com.example.navigation.MyPage
+import com.example.navigation.MyPageTab
 import com.example.navigation.Navigator
 import com.example.navigation.Record
 import com.example.navigation.Search
+import com.example.ui.controller.LocalModalController
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.filter
 
 @Composable
 fun HomeRoute(
@@ -81,7 +81,7 @@ fun HomeRoute(
                 }
 
                 is HomeContract.HomeSideEffect.NavigateToMyPage -> {
-                    // TODO
+                    navigator.navigateTo(destination = MyPage(initialTab = MyPageTab.BOOKMARKED))
                 }
 
                 is HomeContract.HomeSideEffect.ShowLockedModal -> {

--- a/feature/home/src/main/java/com/example/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/example/home/HomeScreen.kt
@@ -26,17 +26,17 @@ import com.example.designsystem.component.DPlayLargeCover
 import com.example.designsystem.component.DPlaySubjectItem
 import com.example.designsystem.component.DplayClickableIcon
 import com.example.designsystem.component.DplayLogoTopAppBar
+import com.example.designsystem.component.button.DPlayBookmarkButton
 import com.example.designsystem.component.chip.DPlayChip
 import com.example.designsystem.component.chip.type.DPlayChipType
 import com.example.designsystem.component.snackbar.LocalShowSnackBar
 import com.example.designsystem.theme.DPlayTheme
-import com.example.domain.model.Badge
+import com.example.domain.model.BADGE
 import com.example.domain.model.FeedItem
 import com.example.navigation.Detail
 import com.example.navigation.Navigator
 import com.example.navigation.Record
 import kotlinx.coroutines.flow.collectLatest
-import kotlin.math.absoluteValue
 
 @Composable
 fun HomeRoute(
@@ -61,7 +61,7 @@ fun HomeRoute(
                     navigator.navigateTo(
                         Detail(
                             postId = it.postId,
-                            date = state.todayQuestion.recordMMDD,
+                            badge = it.badge,
                         ),
                     )
                 }
@@ -174,9 +174,9 @@ private fun HomePager(
     val currentChipType: DPlayChipType? =
         currentItem?.badge?.let {
             when (it) {
-                Badge.BEST -> DPlayChipType.BEST
-                Badge.EDITOR -> DPlayChipType.EDITOR
-                Badge.NEW -> DPlayChipType.NEW
+                BADGE.BEST -> DPlayChipType.BEST
+                BADGE.EDITOR -> DPlayChipType.EDITOR
+                BADGE.NEW -> DPlayChipType.NEW
             }
         }
 
@@ -190,20 +190,11 @@ private fun HomePager(
                 pageSpacing = 24.dp,
             ) { page ->
                 val item = feedItems[page]
-
-                val pageOffset =
-                    (
-                        (pagerState.currentPage - page) +
-                            pagerState.currentPageOffsetFraction
-                    ).absoluteValue
-
-                val isCenter = pageOffset < 0.2f
                 val isLockedPage = uiState.locked && page >= 3
 
                 DPlayLargeCover(
                     modifier = Modifier.fillMaxWidth(),
                     isLocked = isLockedPage,
-                    isBookmarkChecked = item.isScrapped,
                     isLikeChecked = item.like.isLiked,
                     likeCount = item.like.count,
                     writerProfileImageUrl = item.writer.profileImg,
@@ -212,11 +203,9 @@ private fun HomePager(
                     musicImageUrl = item.track.coverImg,
                     onStreamClick = { onStreamClick(item.track.trackId) },
                     onLikeClick = { onLikeClick(item.postId) },
-                    onBookmarkClick = { onBookmarkClick(item.postId) },
                     onCoverClick = { if (!isLockedPage) onPostClick(item.postId) },
                     onWriterProfileClick = { onWriterProfileClick(item.writer.userId) },
                     isStreaming = uiState.streamingTrackId == item.track.trackId,
-                    bookmarkIconVisible = isCenter,
                 )
             }
         }
@@ -227,6 +216,19 @@ private fun HomePager(
                 DPlayChip(
                     type = it,
                     modifier = Modifier.align(Alignment.TopCenter),
+                )
+            }
+
+        currentItem
+            ?.takeIf { !isCurrentPageLocked }
+            ?.let {
+                DPlayBookmarkButton(
+                    isMarked = it.isScrapped,
+                    onClick = { onBookmarkClick(it.postId) },
+                    modifier =
+                        Modifier
+                            .align(Alignment.TopEnd)
+                            .padding(top = 52.dp, end = 40.dp),
                 )
             }
     }

--- a/feature/home/src/main/java/com/example/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/example/home/HomeScreen.kt
@@ -15,8 +15,10 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -33,10 +35,13 @@ import com.example.designsystem.component.snackbar.LocalShowSnackBar
 import com.example.designsystem.theme.DPlayTheme
 import com.example.domain.model.BADGE
 import com.example.domain.model.FeedItem
+import com.example.ui.controller.LocalModalController
 import com.example.navigation.Detail
 import com.example.navigation.Navigator
 import com.example.navigation.Record
+import com.example.navigation.Search
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.filter
 
 @Composable
 fun HomeRoute(
@@ -45,6 +50,11 @@ fun HomeRoute(
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     val showSnackBar = LocalShowSnackBar.current
+    val modalController = LocalModalController.current
+
+    val lockedModalMainText = stringResource(R.string.recommend_prompt_modal_main_text)
+    val lockedModalSubText = stringResource(R.string.recommend_prompt_modal_sub_text)
+    val lockedModalButtonLabel = stringResource(R.string.recommend_prompt_modal_button_label)
 
     LaunchedEffect(viewModel.sideEffect) {
         viewModel.sideEffect.collectLatest {
@@ -73,6 +83,21 @@ fun HomeRoute(
                 is HomeContract.HomeSideEffect.NavigateToMyPage -> {
                     // TODO
                 }
+
+                is HomeContract.HomeSideEffect.ShowLockedModal -> {
+                    modalController.showGraphicModal(
+                        mainText = lockedModalMainText,
+                        subText = lockedModalSubText,
+                        buttonLabel = lockedModalButtonLabel,
+                        onButtonClick = {
+                            modalController.hideModal()
+                            navigator.navigateTo(destination = Search)
+                        },
+                        onDismiss = {
+                            modalController.hideModal()
+                        },
+                    )
+                }
             }
         }
     }
@@ -99,6 +124,9 @@ fun HomeRoute(
         onListClick = {
             viewModel.handleIntent(HomeContract.HomeIntent.OnListClick)
         },
+        onLockedCoverClick = {
+            viewModel.handleIntent(HomeContract.HomeIntent.OnLockedCoverClick)
+        },
     )
 }
 
@@ -112,6 +140,7 @@ private fun HomeScreen(
     onLikeClick: (postId: Long) -> Unit,
     onWriterProfileClick: (Long) -> Unit,
     onListClick: () -> Unit,
+    onLockedCoverClick: () -> Unit,
 ) {
     Column(
         modifier = Modifier.fillMaxSize(),
@@ -148,6 +177,7 @@ private fun HomeScreen(
             onStreamClick = onStreamClick,
             onLikeClick = onLikeClick,
             onWriterProfileClick = onWriterProfileClick,
+            onLockedCoverClick = onLockedCoverClick,
             uiState = uiState,
         )
     }
@@ -161,6 +191,7 @@ private fun HomePager(
     onStreamClick: (trackId: String) -> Unit,
     onLikeClick: (postId: Long) -> Unit,
     onWriterProfileClick: (Long) -> Unit,
+    onLockedCoverClick: () -> Unit,
     uiState: HomeContract.HomeState,
 ) {
     val pagerState = rememberPagerState(pageCount = { feedItems.size })
@@ -199,7 +230,13 @@ private fun HomePager(
                     musicImageUrl = item.track.coverImg,
                     onStreamClick = { onStreamClick(item.track.trackId) },
                     onLikeClick = { onLikeClick(item.postId) },
-                    onCoverClick = { if (!isLockedPage) onPostClick(item.postId) },
+                    onCoverClick = {
+                        if (isLockedPage) {
+                            onLockedCoverClick()
+                        } else {
+                            onPostClick(item.postId)
+                        }
+                    },
                     onWriterProfileClick = { onWriterProfileClick(item.writer.userId) },
                     isStreaming = uiState.streamingTrackId == item.track.trackId,
                 )
@@ -245,6 +282,7 @@ private fun HomePreview() {
             onWriterProfileClick = {},
             onRefresh = {},
             onListClick = {},
+            onLockedCoverClick = {},
         )
     }
 }

--- a/feature/home/src/main/java/com/example/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/example/home/HomeScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -51,6 +52,7 @@ fun HomeRoute(
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     val showSnackBar = LocalShowSnackBar.current
     val modalController = LocalModalController.current
+    val pagerState = rememberPagerState(pageCount = { state.feedItems.size })
 
     val lockedModalMainText = stringResource(R.string.recommend_prompt_modal_main_text)
     val lockedModalSubText = stringResource(R.string.recommend_prompt_modal_sub_text)
@@ -98,11 +100,16 @@ fun HomeRoute(
                         },
                     )
                 }
+
+                is HomeContract.HomeSideEffect.ScrollToFirstPage -> {
+                    pagerState.animateScrollToPage(0)
+                }
             }
         }
     }
     HomeScreen(
         uiState = state,
+        pagerState = pagerState,
         onRefresh = {
             viewModel.handleIntent(HomeContract.HomeIntent.OnRefreshClick)
         },
@@ -133,6 +140,7 @@ fun HomeRoute(
 @Composable
 private fun HomeScreen(
     uiState: HomeContract.HomeState = HomeContract.HomeState(),
+    pagerState: PagerState,
     onRefresh: () -> Unit,
     onPostClick: (postId: Long) -> Unit,
     onBookmarkClick: (postId: Long) -> Unit,
@@ -171,6 +179,7 @@ private fun HomeScreen(
         )
         Spacer(modifier = Modifier.height(32.dp))
         HomePager(
+            pagerState = pagerState,
             feedItems = uiState.feedItems,
             onPostClick = onPostClick,
             onBookmarkClick = onBookmarkClick,
@@ -185,6 +194,7 @@ private fun HomeScreen(
 
 @Composable
 private fun HomePager(
+    pagerState: PagerState,
     feedItems: List<FeedItem>,
     onPostClick: (postId: Long) -> Unit,
     onBookmarkClick: (postId: Long) -> Unit,
@@ -194,7 +204,6 @@ private fun HomePager(
     onLockedCoverClick: () -> Unit,
     uiState: HomeContract.HomeState,
 ) {
-    val pagerState = rememberPagerState(pageCount = { feedItems.size })
 
     val currentItem = feedItems.getOrNull(pagerState.currentPage)
     val isCurrentPageLocked = uiState.locked && pagerState.currentPage >= 3
@@ -275,6 +284,7 @@ private fun HomePager(
 private fun HomePreview() {
     DPlayTheme {
         HomeScreen(
+            pagerState = rememberPagerState(pageCount = { 0 }),
             onPostClick = {},
             onBookmarkClick = {},
             onStreamClick = {},

--- a/feature/home/src/main/java/com/example/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/example/home/HomeScreen.kt
@@ -30,6 +30,7 @@ import com.example.designsystem.component.chip.DPlayChip
 import com.example.designsystem.component.chip.type.DPlayChipType
 import com.example.designsystem.component.snackbar.LocalShowSnackBar
 import com.example.designsystem.theme.DPlayTheme
+import com.example.domain.model.Badge
 import com.example.domain.model.FeedItem
 import com.example.navigation.Detail
 import com.example.navigation.Navigator
@@ -171,12 +172,11 @@ private fun HomePager(
     val currentItem = feedItems.getOrNull(pagerState.currentPage)
     val isCurrentPageLocked = uiState.locked && pagerState.currentPage >= 3
     val currentChipType: DPlayChipType? =
-        currentItem?.let {
-            when {
-                it.badges.isPopular -> DPlayChipType.BEST
-                it.badges.isEditorPick -> DPlayChipType.EDITOR
-                it.badges.isNew -> DPlayChipType.NEW
-                else -> null
+        currentItem?.badge?.let {
+            when (it) {
+                Badge.BEST -> DPlayChipType.BEST
+                Badge.EDITOR -> DPlayChipType.EDITOR
+                Badge.NEW -> DPlayChipType.NEW
             }
         }
 

--- a/feature/home/src/main/java/com/example/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/example/home/HomeViewModel.kt
@@ -3,7 +3,7 @@ package com.example.home
 import androidx.lifecycle.viewModelScope
 import com.example.common.audio.AudioPlayer
 import com.example.designsystem.component.snackbar.type.SnackBarType
-import com.example.domain.model.Badges
+import com.example.domain.model.Badge
 import com.example.domain.model.FeedItem
 import com.example.domain.model.Like
 import com.example.domain.model.Track
@@ -103,12 +103,7 @@ class HomeViewModel
                     postId = -1L,
                     isScrapped = false,
                     content = "",
-                    badges =
-                        Badges(
-                            isEditorPick = false,
-                            isPopular = false,
-                            isNew = false,
-                        ),
+                    badge = null,
                     track =
                         Track(
                             trackId = "",
@@ -252,12 +247,7 @@ val dummyFeedItems =
             postId = 111,
             isScrapped = true,
             content = "그냥 좋아요 이 노래",
-            badges =
-                Badges(
-                    isEditorPick = false,
-                    isPopular = true,
-                    isNew = true,
-                ),
+            badge = Badge.BEST,
             track =
                 Track(
                     trackId = "apple:203948",
@@ -282,12 +272,7 @@ val dummyFeedItems =
             postId = 112,
             isScrapped = false,
             content = "비 오는 날 꼭 듣는 노래에요",
-            badges =
-                Badges(
-                    isEditorPick = true,
-                    isPopular = false,
-                    isNew = false,
-                ),
+            badge = Badge.EDITOR,
             track =
                 Track(
                     trackId = "apple:204837",
@@ -312,12 +297,7 @@ val dummyFeedItems =
             postId = 113,
             isScrapped = false,
             content = "출근길에 항상 듣습니다!",
-            badges =
-                Badges(
-                    isEditorPick = false,
-                    isPopular = false,
-                    isNew = true,
-                ),
+            badge = Badge.NEW,
             track =
                 Track(
                     trackId = "apple:204111",
@@ -342,12 +322,7 @@ val dummyFeedItems =
             postId = 113,
             isScrapped = false,
             content = "출근길에 항상 듣습니다!",
-            badges =
-                Badges(
-                    isEditorPick = false,
-                    isPopular = false,
-                    isNew = true,
-                ),
+            badge = Badge.NEW,
             track =
                 Track(
                     trackId = "apple:204111",
@@ -372,12 +347,7 @@ val dummyFeedItems =
             postId = 113,
             isScrapped = false,
             content = "출근길에 항상 듣습니다!",
-            badges =
-                Badges(
-                    isEditorPick = false,
-                    isPopular = false,
-                    isNew = true,
-                ),
+            badge = Badge.NEW,
             track =
                 Track(
                     trackId = "apple:204111",
@@ -402,12 +372,7 @@ val dummyFeedItems =
             postId = 113,
             isScrapped = false,
             content = "출근길에 항상 듣습니다!",
-            badges =
-                Badges(
-                    isEditorPick = false,
-                    isPopular = false,
-                    isNew = true,
-                ),
+            badge = Badge.NEW,
             track =
                 Track(
                     trackId = "apple:204111",

--- a/feature/home/src/main/java/com/example/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/example/home/HomeViewModel.kt
@@ -69,6 +69,10 @@ class HomeViewModel
                     val badge = currentState.feedItems.find { it.postId == intent.postId }?.badge
                     setSideEffect(HomeContract.HomeSideEffect.NavigateToPostDetail(postId = intent.postId, badge = badge))
                 }
+
+                is HomeContract.HomeIntent.OnLockedCoverClick -> {
+                    setSideEffect(HomeContract.HomeSideEffect.ShowLockedModal)
+                }
             }
         }
 

--- a/feature/home/src/main/java/com/example/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/example/home/HomeViewModel.kt
@@ -3,7 +3,7 @@ package com.example.home
 import androidx.lifecycle.viewModelScope
 import com.example.common.audio.AudioPlayer
 import com.example.designsystem.component.snackbar.type.SnackBarType
-import com.example.domain.model.Badge
+import com.example.domain.model.BADGE
 import com.example.domain.model.FeedItem
 import com.example.domain.model.Like
 import com.example.domain.model.Track
@@ -24,7 +24,7 @@ import javax.inject.Inject
 class HomeViewModel
     @Inject
     constructor(
-        val postRepository: PostRepository,
+        private val postRepository: PostRepository,
         private val trackRepository: TrackRepository,
         private val audioPlayer: AudioPlayer,
     ) : BaseViewModel<HomeContract.HomeState, HomeContract.HomeIntent, HomeContract.HomeSideEffect>(
@@ -66,7 +66,8 @@ class HomeViewModel
                 }
 
                 is HomeContract.HomeIntent.OnCoverClick -> {
-                    setSideEffect(HomeContract.HomeSideEffect.NavigateToPostDetail(postId = intent.postId))
+                    val badge = currentState.feedItems.find { it.postId == intent.postId }?.badge
+                    setSideEffect(HomeContract.HomeSideEffect.NavigateToPostDetail(postId = intent.postId, badge = badge))
                 }
             }
         }
@@ -247,7 +248,7 @@ val dummyFeedItems =
             postId = 111,
             isScrapped = true,
             content = "그냥 좋아요 이 노래",
-            badge = Badge.BEST,
+            badge = BADGE.BEST,
             track =
                 Track(
                     trackId = "apple:203948",
@@ -272,7 +273,7 @@ val dummyFeedItems =
             postId = 112,
             isScrapped = false,
             content = "비 오는 날 꼭 듣는 노래에요",
-            badge = Badge.EDITOR,
+            badge = BADGE.EDITOR,
             track =
                 Track(
                     trackId = "apple:204837",
@@ -297,7 +298,7 @@ val dummyFeedItems =
             postId = 113,
             isScrapped = false,
             content = "출근길에 항상 듣습니다!",
-            badge = Badge.NEW,
+            badge = BADGE.NEW,
             track =
                 Track(
                     trackId = "apple:204111",
@@ -322,7 +323,7 @@ val dummyFeedItems =
             postId = 113,
             isScrapped = false,
             content = "출근길에 항상 듣습니다!",
-            badge = Badge.NEW,
+            badge = BADGE.NEW,
             track =
                 Track(
                     trackId = "apple:204111",
@@ -347,7 +348,7 @@ val dummyFeedItems =
             postId = 113,
             isScrapped = false,
             content = "출근길에 항상 듣습니다!",
-            badge = Badge.NEW,
+            badge = BADGE.NEW,
             track =
                 Track(
                     trackId = "apple:204111",
@@ -372,7 +373,7 @@ val dummyFeedItems =
             postId = 113,
             isScrapped = false,
             content = "출근길에 항상 듣습니다!",
-            badge = Badge.NEW,
+            badge = BADGE.NEW,
             track =
                 Track(
                     trackId = "apple:204111",

--- a/feature/home/src/main/java/com/example/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/example/home/HomeViewModel.kt
@@ -78,7 +78,7 @@ class HomeViewModel
                     .getTodayPosts()
                     .onSuccess { data ->
                         val feedItems =
-                            if (data.locked && data.totalCount >= 4) {
+                            if (data.locked) {
                                 data.todayPosts + lockedDummyFeedItem
                             } else {
                                 data.todayPosts

--- a/feature/home/src/main/java/com/example/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/example/home/HomeViewModel.kt
@@ -32,6 +32,7 @@ class HomeViewModel
         ) {
         init {
             observePlaybackState()
+            getTodayPosts()
         }
 
         private fun observePlaybackState() {
@@ -52,7 +53,6 @@ class HomeViewModel
 
         override fun handleIntent(intent: HomeContract.HomeIntent) {
             when (intent) {
-                is HomeContract.HomeIntent.LoadHomeData -> getTodayPosts()
                 is HomeContract.HomeIntent.OnBookmarkClick -> toggleBookmark(intent.postId)
                 is HomeContract.HomeIntent.OnLikeClick -> toggleLike(intent.postId)
                 is HomeContract.HomeIntent.OnRefreshClick -> refreshTodayPosts()

--- a/feature/home/src/main/java/com/example/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/example/home/HomeViewModel.kt
@@ -173,6 +173,7 @@ class HomeViewModel
 
         private fun refreshTodayPosts() {
             getTodayPosts()
+            setSideEffect(HomeContract.HomeSideEffect.ScrollToFirstPage)
         }
 
         private fun toggleBookmark(postId: Long) {

--- a/feature/home/src/main/java/com/example/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/example/home/HomeViewModel.kt
@@ -2,6 +2,7 @@ package com.example.home
 
 import androidx.lifecycle.viewModelScope
 import com.example.common.audio.AudioPlayer
+import com.example.common.event.HomeRefreshTrigger
 import com.example.designsystem.component.snackbar.type.SnackBarType
 import com.example.domain.model.BADGE
 import com.example.domain.model.FeedItem
@@ -27,11 +28,13 @@ class HomeViewModel
         private val postRepository: PostRepository,
         private val trackRepository: TrackRepository,
         private val audioPlayer: AudioPlayer,
+        private val homeRefreshTrigger: HomeRefreshTrigger,
     ) : BaseViewModel<HomeContract.HomeState, HomeContract.HomeIntent, HomeContract.HomeSideEffect>(
             HomeContract.HomeState(),
         ) {
         init {
             observePlaybackState()
+            observeRefreshTrigger()
             getTodayPosts()
         }
 
@@ -48,6 +51,13 @@ class HomeViewModel
                                 },
                         )
                     }
+                }.launchIn(viewModelScope)
+        }
+
+        private fun observeRefreshTrigger() {
+            homeRefreshTrigger.refreshEvent
+                .onEach {
+                    getTodayPosts()
                 }.launchIn(viewModelScope)
         }
 

--- a/feature/main/src/main/java/com/example/main/BottomNavigationBar.kt
+++ b/feature/main/src/main/java/com/example/main/BottomNavigationBar.kt
@@ -60,7 +60,7 @@ fun BottomNavigationBar(
             ) {
                 topLevelRouteList.forEach { tab ->
                     BottomNavigationItem(
-                        isSelected = currentTab == tab,
+                        isSelected = currentTab?.let { it::class == tab::class } ?: false,
                         tab = tab,
                         onBottomNavigationItemClick = { onBottomNavigationItemClick(it) },
                     )
@@ -107,7 +107,7 @@ fun BottomNavigationBarPreview() {
     DPlayTheme {
         BottomNavigationBar(
             isVisible = true,
-            topLevelRouteList = persistentListOf(Home, MyPage),
+            topLevelRouteList = persistentListOf(Home, MyPage()),
             currentTab = currentTab,
             onBottomNavigationItemClick = {
                 currentTab = it

--- a/feature/mypage/src/main/java/com/example/mypage/MyPageNavigationModule.kt
+++ b/feature/mypage/src/main/java/com/example/mypage/MyPageNavigationModule.kt
@@ -19,8 +19,11 @@ object MyPageNavigationModule {
         navigator: Navigator,
     ): EntryProviderScope<NavKey>.() -> Unit =
         {
-            entry<MyPage> {
-                MyPageRoute(navigator = navigator)
+            entry<MyPage> { myPage ->
+                MyPageRoute(
+                    navigator = navigator,
+                    initialTab = myPage.initialTab,
+                )
             }
         }
 }

--- a/feature/mypage/src/main/java/com/example/mypage/MyPageScreen.kt
+++ b/feature/mypage/src/main/java/com/example/mypage/MyPageScreen.kt
@@ -72,8 +72,8 @@ import kotlinx.coroutines.flow.collectLatest
 @Composable
 fun MyPageRoute(
     navigator: Navigator,
-    initialTab: MyPageTab = MyPageTab.REGISTERED,
     modifier: Modifier = Modifier,
+    initialTab: MyPageTab = MyPageTab.REGISTERED,
     viewModel: MyPageViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()

--- a/feature/mypage/src/main/java/com/example/mypage/MyPageScreen.kt
+++ b/feature/mypage/src/main/java/com/example/mypage/MyPageScreen.kt
@@ -58,6 +58,7 @@ import com.example.designsystem.theme.DPlayTheme
 import com.example.designsystem.util.noRippleClickable
 import com.example.navigation.Detail
 import com.example.navigation.EditProfile
+import com.example.navigation.MyPageTab
 import com.example.navigation.Navigator
 import com.example.navigation.Setting
 import com.example.ui.controller.LocalBottomNavigationController
@@ -70,10 +71,20 @@ import kotlinx.coroutines.flow.collectLatest
 @Composable
 fun MyPageRoute(
     navigator: Navigator,
+    initialTab: MyPageTab = MyPageTab.REGISTERED,
     modifier: Modifier = Modifier,
     viewModel: MyPageViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
+
+    LaunchedEffect(initialTab) {
+        val tabIndex =
+            when (initialTab) {
+                MyPageTab.REGISTERED -> 0
+                MyPageTab.BOOKMARKED -> 1
+            }
+        viewModel.handleIntent(MyPageContract.MyPageIntent.OnTabClick(tabIndex))
+    }
 
     val registeredTracks = viewModel.registeredTracks.collectAsLazyPagingItems()
     val scrappedTracks = viewModel.scrappedTracks.collectAsLazyPagingItems()

--- a/feature/mypage/src/main/java/com/example/mypage/MyPageScreen.kt
+++ b/feature/mypage/src/main/java/com/example/mypage/MyPageScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -76,14 +77,18 @@ fun MyPageRoute(
     viewModel: MyPageViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
+    var hasAppliedInitialTab by rememberSaveable { mutableStateOf(false) }
 
-    LaunchedEffect(initialTab) {
-        val tabIndex =
-            when (initialTab) {
-                MyPageTab.REGISTERED -> 0
-                MyPageTab.BOOKMARKED -> 1
-            }
-        viewModel.handleIntent(MyPageContract.MyPageIntent.OnTabClick(tabIndex))
+    LaunchedEffect(Unit) {
+        if (!hasAppliedInitialTab) {
+            val tabIndex =
+                when (initialTab) {
+                    MyPageTab.REGISTERED -> 0
+                    MyPageTab.BOOKMARKED -> 1
+                }
+            viewModel.handleIntent(MyPageContract.MyPageIntent.OnTabClick(tabIndex))
+            hasAppliedInitialTab = true
+        }
     }
 
     val registeredTracks = viewModel.registeredTracks.collectAsLazyPagingItems()

--- a/feature/record/src/main/java/com/example/record/RecordListScreen.kt
+++ b/feature/record/src/main/java/com/example/record/RecordListScreen.kt
@@ -21,6 +21,7 @@ import com.example.designsystem.component.DPlayMusicListItem
 import com.example.designsystem.component.DPlaySubjectItem
 import com.example.designsystem.component.DplayLeftIconTitleTopAppBar
 import com.example.designsystem.theme.DPlayTheme
+import com.example.domain.model.BADGE
 import com.example.domain.model.FeedItem
 import com.example.ui.emptyLazyPagingItems
 
@@ -71,7 +72,7 @@ fun RecordListScreen(
                     musicArtistName = item.track.artistName,
                     musicContent = item.content,
                     onMoreClick = {},
-                    isEditorPick = item.badges.isEditorPick,
+                    isEditorPick = (item.badge == BADGE.EDITOR),
                     onClick = { onMusicClick(item.postId) },
                 )
             }

--- a/feature/record/src/main/java/com/example/record/RecordListScreen.kt
+++ b/feature/record/src/main/java/com/example/record/RecordListScreen.kt
@@ -71,7 +71,6 @@ fun RecordListScreen(
                     musicName = item.track.songTitle,
                     musicArtistName = item.track.artistName,
                     musicContent = item.content,
-                    onMoreClick = {},
                     isEditorPick = (item.badge == BADGE.EDITOR),
                     onClick = { onMusicClick(item.postId) },
                 )


### PR DESCRIPTION
## Related issue 🛠
- closed #87

## Work Description ✏️
### Home
- 홈 뷰모델 init으로 초기 데이터 로드
- 홈 북마크 위치 고정
- 오늘 노래가 3개여도 잠금 UI 표시
- 잠금 앨범 클릭 시 모달 추가
- 글 등록/삭제 후 홈 데이터 새로고침
- 새로고침 버튼 클릭 시 첫 번째 노래로 스크롤
### Detail
- 상세화면에 badge 전달
- 글 삭제 확인 모달 추가
### MyPage
- 북마크 스낵바 액션 클릭 시 마이페이지 보관함 탭으로 이동
- 탭 유지 로직 추가 (상세화면 갔다가 돌아와도 탭 유지)
### BottomSheet
- 신고하기 바텀시트 단일 선택으로 변경 및 미선택 시 버튼 비활성화
### Record
- 과거 추천 기록 노래 리스트 아이템 미트볼 버튼 삭제
### Common
- BADGE enum class 적용
- date 서버 응답 반영
- 노래 제목, 가수 한 줄 제한 추가

## Screenshot 📸
- 영상/이미지 첨부

## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
커밋 기준으로 변경사항 확인하시면 좋을 것 같아요~